### PR TITLE
PHP 7.4 Preloading: define 'scan()' function only if not already defined for 2.x branch

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -16,7 +16,9 @@ if (defined('Swagger\UNDEFINED') === false) {
     define('Swagger\UNDEFINED', '{SWAGGER-PHP-UNDEFINED-46EC-07AB32D2-D50C}');
     define('Swagger\Annotations\UNDEFINED', UNDEFINED);
     define('Swagger\Processors\UNDEFINED', UNDEFINED);
+}
 
+if (function_exists('Swagger\scan') === false) {
     /**
      * Scan the filesystem for swagger annotations and build swagger-documentation.
      *


### PR DESCRIPTION
Hi guys,

same fixes to https://github.com/zircote/swagger-php/pull/748 but for 2.x version